### PR TITLE
add link to another vertical slice project

### DIFF
--- a/docs/vertical-slice-architecture.md
+++ b/docs/vertical-slice-architecture.md
@@ -1,12 +1,12 @@
-	
+
 # Vertical Slice Architecture
 
 ## 📕 Articles
 - [Vertical Slice Architecture](https://jimmybogard.com/vertical-slice-architecture/) ⭐
-- [Package by component and architecturally-aligned testing](https://dzone.com/articles/package-component-and) 
-- [An architecturally-evident coding style](https://dzone.com/articles/architecturally-evident-coding) 
+- [Package by component and architecturally-aligned testing](https://dzone.com/articles/package-component-and)
+- [An architecturally-evident coding style](https://dzone.com/articles/architecturally-evident-coding)
 - [Exploring vertical slices in dotnet core](https://dev.to/htech/exploring-vertical-slices-in-dotnet-core-3mik)
-- [Package by Component with Clean Modules in Java](https://blog.ttulka.com/package-by-component-with-clean-modules-in-java) 
+- [Package by Component with Clean Modules in Java](https://blog.ttulka.com/package-by-component-with-clean-modules-in-java)
 - [Architecting for maintainability through Vertical Slices ](https://www.ghyston.com/insights/architecting-for-maintainability-through-vertical-slices/) ⭐
 - [The Tyranny of Horizontal Architectures (and How You Might Escape): Part 2](https://www.ojdevelops.com/2018/07/the-tyranny-of-horizontal-architectures2.html)
 - [Organizing Code by Feature using Vertical Slices](https://codeopinion.com/organizing-code-by-feature-using-vertical-slices/) ⭐
@@ -17,12 +17,12 @@
 - [Put your controllers on a diet: GETs and queries](https://lostechies.com/jimmybogard/2013/10/29/put-your-controllers-on-a-diet-gets-and-queries/)
 - [Put your controllers on a diet: POSTs and commands](https://lostechies.com/jimmybogard/2013/12/19/put-your-controllers-on-a-diet-posts-and-commands/)
 - [The life-changing (and time-saving!) magic of Feature Focused code organisation.](https://builtwithdot.net/blog/changing-how-your-code-is-organized-could-speed-development-from-weeks-to-days)
-- [Migrating Contoso University Example to Razor Pages](https://jimmybogard.com/migrating-contoso-university-example-to-razor-pages/) 
+- [Migrating Contoso University Example to Razor Pages](https://jimmybogard.com/migrating-contoso-university-example-to-razor-pages/)
 - [API Feature Folders](https://ardalis.com/api-feature-folders/)
-- [Feature Slices for ASP.NET Core MVC](https://docs.microsoft.com/en-us/archive/msdn-magazine/2016/september/asp-net-core-feature-slices-for-asp-net-core-mvc) 
-- [Simpler ASP.NET MVC Apps with Razor Pages](https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/september/asp-net-core-simpler-asp-net-mvc-apps-with-razor-pages) 
-- [Moving from Controllers and Actions to Endpoints with MediatR](https://ardalis.com/moving-from-controllers-and-actions-to-endpoints-with-mediatr/) 
-- [MVC Controllers are Dinosaurs - Embrace API Endpoints](https://ardalis.com/mvc-controllers-are-dinosaurs-embrace-api-endpoints/) 
+- [Feature Slices for ASP.NET Core MVC](https://docs.microsoft.com/en-us/archive/msdn-magazine/2016/september/asp-net-core-feature-slices-for-asp-net-core-mvc)
+- [Simpler ASP.NET MVC Apps with Razor Pages](https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/september/asp-net-core-simpler-asp-net-mvc-apps-with-razor-pages)
+- [Moving from Controllers and Actions to Endpoints with MediatR](https://ardalis.com/moving-from-controllers-and-actions-to-endpoints-with-mediatr/)
+- [MVC Controllers are Dinosaurs - Embrace API Endpoints](https://ardalis.com/mvc-controllers-are-dinosaurs-embrace-api-endpoints/)
 - [Out with the Onion, in with Vertical Slices](https://medium.com/@jacobcunningham/out-with-the-onion-in-with-vertical-slices-c3edfdafe118)
 - [No Abstractions in Vertical Slice Architecture?](https://www.reddit.com/r/dotnet/comments/m1t6g3/no_abstractions_in_vertical_slice_architecture/)
 - [Encountering "Vertical Slice Architecture"... Is it incompatible with Clean Architecture?](https://jeremiahflaga.github.io/2019/05/20/vertical-slice-architecture-is-it-incompatible-with-clean-architecture/)
@@ -32,7 +32,7 @@
 - [Composite UIs for Microservices: Vertical Slice APIs](https://jimmybogard.com/composite-uis-for-microservices-vertical-slice-apis/)
 - [How to slice the codebase effectively?](https://event-driven.io/en/how_to_slice_the_codebase_effectively/) ⭐
 - [Fat Controller CQRS Diet: Vertical Slices](https://codeopinion.com/fat-controller-cqrs-diet-vertical-slices/)
-- [CQRS facts and myths explained](https://event-driven.io/en/cqrs_facts_and_myths_explained/) 
+- [CQRS facts and myths explained](https://event-driven.io/en/cqrs_facts_and_myths_explained/)
 - [Slices vs. Layers](https://www.betterask.erni/news-room/slices-vs-layers/)
 - [Modular Monolith: A Primer](http://www.kamilgrzybek.com/design/modular-monolith-primer/)
 - [Choosing Between using Clean/Onion or Vertical Slice Architecture for Enterprise Apps in .NET](https://www.reddit.com/r/dotnet/comments/lw13r2/choosing_between_using_cleanonion_or_vertical/)
@@ -58,9 +58,9 @@
 
 ## 📺 Videos
 - [SOLID Architecture in Slices not Layers - Jimmy Bogard](https://vimeo.com/131633177)
-- [Vertical Slice Architecture - Jimmy Bogard](https://www.youtube.com/watch?v=5kOzZz2vj2o) 
-- [SOLID Architecture in Slices not Layers](https://www.youtube.com/watch?v=wTd-VcJCs_M) 
-- [DevTernity 2019: Jimmy Bogard – Vertical Slice Architecture](https://www.youtube.com/watch?v=T6nglsEDaqA) 
+- [Vertical Slice Architecture - Jimmy Bogard](https://www.youtube.com/watch?v=5kOzZz2vj2o)
+- [SOLID Architecture in Slices not Layers](https://www.youtube.com/watch?v=wTd-VcJCs_M)
+- [DevTernity 2019: Jimmy Bogard – Vertical Slice Architecture](https://www.youtube.com/watch?v=T6nglsEDaqA)
 - [Vertical Slice Architecture - Jimmy Bogard](https://www.youtube.com/watch?v=SUiWfhAhgQw&lc=UgzDmpq_2SHwmuSgIL54AaABAg)
 - [Blazor Server Vertical Slice Architecture](https://www.youtube.com/watch?v=WLNEeO5cMaw)
 - [Restructuring to a Vertical Slice Architecture](https://www.youtube.com/watch?v=cVVMbuKmNes)
@@ -75,15 +75,15 @@
 - [Vertical Slice Architecture (Jimmy Bogard)](https://www.youtube.com/watch?v=oAoaMlS1PWo)
 
 ## 🚀 Samples
-- [jbogard/ContosoUniversityDotNetCore-Pages](https://github.com/jbogard/ContosoUniversityDotNetCore-Pages) 
+- [jbogard/ContosoUniversityDotNetCore-Pages](https://github.com/jbogard/ContosoUniversityDotNetCore-Pages)
 - [oskardudycz/EventSourcing.NetCore/Sample/Warehouse](https://github.com/oskardudycz/EventSourcing.NetCore/tree/cqrs_with_net5/Sample/Warehouse)
 - [sandeepgangwar/Vertical-Slice-Architecture](https://github.com/sandeepgangwar/Vertical-Slice-Architecture)
 - [dj-nitehawk/MongoWebApiStarter](https://github.com/dj-nitehawk/MongoWebApiStarter) - A full-featured starter template for `dotnet new` to quickly scaffold a .Net 6 Web-Api project with MongoDB as the data store.
 - [baratgabor/MyWarehouse](https://github.com/baratgabor/MyWarehouse) - Clean Architecture and Domain Driven Design sample project based on C# 9 / .NET 5 / ASP.NET Core 5 / EF Core 5 & Angular 11 with Bootstrap.
 - [gothinkster/aspnetcore-realworld-example-app](https://github.com/gothinkster/aspnetcore-realworld-example-app) - ASP.NET Core backend implementation for RealWorld
-- [dcomartin/MusicStore](https://github.com/dcomartin/MusicStore) 
+- [dcomartin/MusicStore](https://github.com/dcomartin/MusicStore)
 - [ardalis/OrganizingAspNetCore](https://github.com/ardalis/OrganizingAspNetCore)
-- [dotnet-architecture/eShopOnWeb](https://github.com/dotnet-architecture/eShopOnWeb) 
+- [dotnet-architecture/eShopOnWeb](https://github.com/dotnet-architecture/eShopOnWeb)
 - [ardalis/ApiEndpoints/tree/master/sample](https://github.com/ardalis/ApiEndpoints/tree/master/sample)
 - [PacktPublishing/ASP.NET-Core-5-Design-Patterns](https://github.com/PacktPublishing/ASP.NET-Core-5-Design-Patterns/tree/main/C15/Vertical%20Slice%20Architecture)
 - [isaacOjeda/MinimalApiArchitecture](https://github.com/isaacOjeda/MinimalApiArchitecture) ⭐ - .NET 6 Minimal API with Vertical Slice Architecture
@@ -95,5 +95,6 @@
 - [oskardudycz/EventSourcing.JVM](https://github.com/oskardudycz/EventSourcing.JVM) - Examples and Tutorials of Event Sourcing in JVM languages
 - [Hona/VerticalSliceArchitecture](https://github.com/Hona/VerticalSliceArchitecture) - A small but opinionated Vertical Slice Architecture solution template for .NET 8
 - [baranacikgoz/modular-monolith-ddd-vsa-webapi](https://github.com/baranacikgoz/modular-monolith-ddd-vsa-webapi) - A .NET 8 Webapi boilerplate with Modular Monolith approach, Domain-Driven Design and Vertical Slices architecture along with Clean Architecture principles per feature
+- [jonyeezs/clean-verticalslice-architecture](https://github.com/jonyeezs/clean-verticalslice-architecture) - An opinionated framework for building clean vertical slice architecture API. Included in the README are the motivation behind the code structure and explanations of all decisions.
 
 


### PR DESCRIPTION
This takes a slightly different approach from most and contains explanations of its decisions.

Most projects have their link to some other article or video. But they don't explain why things are done in a certain way.

This repo plans to include examples in Java and Go; and potentially Ruby in the future.