### PR TITLE
Add Decision Reasoning Format (DRF)

### DIFF
--- a/docs/architecture-documententation.md
+++ b/docs/architecture-documententation.md
@@ -3,6 +3,7 @@
 ## Resources
 - [arc42/arc42-template](https://github.com/arc42/arc42-template) - arc42 - the template for software architecture documentation and communication
 - [joelparkerhenderson/architecture-decision-record](https://github.com/joelparkerhenderson/architecture-decision-record) - Architecture decision record (ADR) examples for software planning, IT leadership, and template documentation
+- [reasoning-formats/reasoning-formats](https://github.com/reasoning-formats/reasoning-formats) - Decision Reasoning Format (DRF) — a vendor-neutral, machine-readable YAML/JSON format for structured decision documentation with explicit reasoning, cognitive state tracking, and trade-off documentation
 - [C4Model.com](https://c4model.com)
 
 ## Articles


### PR DESCRIPTION
## Summary

- Adds [Decision Reasoning Format (DRF)](https://github.com/reasoning-formats/reasoning-formats) to the Architecture Documentation (ADR) resources section.

DRF complements traditional Architecture Decision Records by providing a fully machine-readable YAML/JSON format with:

- **Structured reasoning patterns** — explicit vocabulary for how decisions were reasoned (operational, risk-based, contrafactual, etc.)
- **Cognitive state tracking** — captures the phase of reasoning (exploration, tension, convergence) and confidence levels
- **Trade-off documentation** — preserves unresolved tensions and accepted trade-offs, not just outcomes
- **Intervention capture** — records key questions and challenges that shaped the decision process

DRF is vendor-neutral, domain-agnostic, and designed to be usable by humans, automation, and AI systems alike.

## Test plan

- [x] Entry follows the existing link format used in the resources section
- [x] Link resolves to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)