### PR TITLE
Add Casino Engine to Hexagonal Architecture Samples

### DIFF
--- a/docs/hexagonal-architecture.md
+++ b/docs/hexagonal-architecture.md
@@ -50,5 +50,6 @@
 - [SketchingDev/hexagonal-lambda](https://github.com/SketchingDev/hexagonal-lambda) - NodeJS project demonstrating an AWS Lambda using Hexagonal architecture.
 - [damonkelley/ports-and-adapters-examples](https://github.com/damonkelley/ports-and-adapters-examples) - Ports and Adapters Examples
 - [tpierrain/hexagonalThis](https://github.com/tpierrain/hexagonalThis) - A simple kata to live-code with Alistair about Hexagonal Architecture
+- [nekzabirov/IGaming-Game-Engine](https://github.com/nekzabirov/IGaming-Game-Engine) - Production iGaming/casino engine in Kotlin/Ktor structured around Hexagonal Architecture: pure domain layer with zero framework deps, application ports for wallet/limits/file/event, and infrastructure adapters for RabbitMQ, S3, gRPC clients, and Exposed (PostgreSQL). Game aggregator integrations (Pragmatic Play, OneGameHub, Pateplay) are pluggable adapters discovered at boot via Koin.
 
 	


### PR DESCRIPTION
## Summary

Adds [nekzabirov/IGaming-Game-Engine](https://github.com/nekzabirov/IGaming-Game-Engine) to **docs/hexagonal-architecture.md → Samples**.

## Why this fits the Hexagonal section

Casino Engine is a production-grade open-source iGaming/casino engine in Kotlin/Ktor structured strictly around the ports & adapters pattern:

- **Domain layer** has zero framework dependencies — aggregates, value objects, repository *interfaces*, sealed exception hierarchy
- **Application layer** declares ports (\`IWalletPort\`, \`IPlayerLimitPort\`, \`FileAdapter\`, \`IEventPort\`) and orchestrates use cases
- **Infrastructure layer** holds adapters: Exposed (PostgreSQL), RabbitMQ, S3, Redis, gRPC clients
- **Three vendor aggregator adapters** (Pragmatic Play, OneGameHub, Pateplay) implement the same \`AggregatorAdapterProvider\` port and are discovered at boot via Koin's \`getAll<T>()\` — adding a fourth vendor is one new file + one Koin line

Production-tested on moonbet.casino and 2k.ua. Apache 2.0.

The samples section currently has examples in .NET, Node.js, and Java, but no Kotlin/Ktor reference at this scale.

## Checklist
- [x] One PR per category (this is the hexagonal-architecture.md PR; separate PRs for CQRS / EDA / gRPC categories are open / coming)
- [x] Entry format matches existing: \`[user/repo](link) - Description\`
- [x] Meaningful description
- [x] Active and maintained