### PR TITLE
Add Uxxu to modeling tools

### DIFF
--- a/docs/modeling/tools.md
+++ b/docs/modeling/tools.md
@@ -3,6 +3,7 @@
 
 - [Diagrams.Net](https://www.diagrams.net)
 - [IcePanel](https://icepanel.io)
+- [Uxxu](https://uxxu.io) - C4 software architecture modeling platform for connected diagrams and shared architecture workspaces.
 - [Vertabelo](https://vertabelo.com)
 - [Reverse engineering - vertabelo](https://vertabelo.com/documentation/physical-model/reverse-engineering-doc/)
 - [LucidChart](https://www.lucidchart.com/pages/)


### PR DESCRIPTION
Adds Uxxu to the Modeling Tools section.

Uxxu is a C4 software architecture modeling platform for creating connected architecture diagrams and shared architecture workspaces. Since it focuses on software architecture modeling and C4 diagrams, the Modeling Tools category is the right place for it.
