### PR TITLE
Add Bogoware.Monads to Functional Programming libraries

### DIFF
--- a/docs/functional.md
+++ b/docs/functional.md
@@ -17,3 +17,4 @@
 ## 📦 Libraries
 - [mcintyre321/OneOf](https://github.com/mcintyre321/OneOf) - Easy to use F#-like ~discriminated~ unions for C# with exhaustive compile time matching
 - [ardalis/Result](https://github.com/ardalis/Result) - A result abstraction that can be mapped to HTTP response codes if needed.
+- [bogoware/Monads](https://github.com/bogoware/Monads) - Result and Maybe monads for railway-oriented functional error handling and safe optional values in C#.


### PR DESCRIPTION
Adds **Bogoware.Monads** to the Functional Programming → Libraries section.

[Bogoware.Monads](https://github.com/bogoware/Monads) provides `Result<T>` and `Maybe<T>` monads for railway-oriented, functional error handling and safe optional values in C# — useful for DDD / domain primitives and explicit error flows.

- 📦 NuGet: https://www.nuget.org/packages/Bogoware.Monads (v11.5.0)
- 📚 Docs: https://bogoware.github.io/Monads/
- ⚖️ MIT licensed, actively maintained

Single category touched (Libraries) in this PR per the contribution guidelines.