### PR TITLE
docs(modeling/tools): add kUML — Kotlin DSL for UML, SysML 2 and C4

### DIFF
--- a/docs/modeling/tools.md
+++ b/docs/modeling/tools.md
@@ -11,3 +11,4 @@
 - [Creately](https://creately.com)
 - [CloudSkew](https://app.cloudskew.com)
 - [ExcaliDraw](https://github.com/excalidraw/excalidraw)
+- [kUML](https://kuml.dev) - [kuml-dev/kUML](https://github.com/kuml-dev/kUML) - Kotlin DSL for UML, SysML 2 and C4 diagrams-as-code. Ships a CLI, a Compose Desktop app, IntelliJ-platform and Obsidian plugins, and an Asciidoctor extension. SVG/PNG renderers with ELK layout, Java/Kotlin reverse engineering, XMI import/export, and a stable plugin SPI (themes, renderers, layouts, codegen, reverse).


### PR DESCRIPTION
## What

Adds [kUML](https://kuml.dev) — [`kuml-dev/kUML`](https://github.com/kuml-dev/kUML) — to `docs/modeling/tools.md`, alongside Diagrams.net, Visual Paradigm, LucidChart, Excalidraw etc.

## Why it fits this list

kUML is a Kotlin-based **diagrams-as-code** toolchain for UML, SysML 2 and C4 — a strong fit for the *Modeling → Tools* category. It treats architectural diagrams as version-controlled source code rather than artefacts of GUI tools.

## Highlights

- **DSL**: Kotlin script (`.kuml.kts`) for UML class/component/sequence/state-machine, SysML 2 (BDD/IBD/STM), and C4 (Context/Container/Component) diagrams.
- **Renderers**: SVG and PNG, content-aware sizing, ELK-Bridge layout plugin.
- **Distribution**: CLI (Homebrew tap, SDKMAN!, direct download, jpackage DMG/MSI/DEB/RPM), Compose Desktop app, IntelliJ-platform plugin, Obsidian community plugin, Asciidoctor extension on Maven Central (`[kuml]` block macro).
- **Interop**: XMI import/export (Eclipse UML2), Structurizr DSL migration, Java/Kotlin reverse engineering (`kuml reverse`).
- **Plugin SPI**: stable extension points for themes, renderers, layout engines, codegen, reverse engineering — signed plugin registry.
- **AI Assistant**: optional Koog-based assistant in the desktop app (multi-LLM, sandboxed patch-apply).
- **License**: Apache-2.0.

## Format

Followed the convention from `contributing.md` (`LINK | GitHub-User/Repo - DESCRIPTION`) and the existing style of neighbouring files. Appended at the end of `docs/modeling/tools.md`.

## Checklist

- [x] One file changed, one category
- [x] Concise, descriptive entry
- [x] Project is open source (Apache-2.0) and actively developed
- [x] Public website + GitHub repo + Maven Central artefacts